### PR TITLE
adjusted the exception of the login method to also include the license status

### DIFF
--- a/fortiosapi/fortiosapi.py
+++ b/fortiosapi/fortiosapi.py
@@ -127,8 +127,10 @@ class FortiOSAPI(object):
         try:
             self._fortiversion = self.monitor('system', 'interface')['version']
         except:
-            raise Exception('can not get following login')
-        # Might be wise to return the license status here
+            license_status = self.monitor('license', 'status')
+            print('can not get following login, check license status')
+            raise Exception(license_status)
+        # Now you can capture the exception and check the license status
 
     def get_version(self):
         return self._fortiversion


### PR DESCRIPTION
Hi,

I was doing some scripts to validate the licensing of a distributed environment and noticed that the current fortiosapi is not able to give me the status if the license is invalid (which is exactly what I need) so I adjusted the Exception to return that value in case of login error.

I'm not sure if this is how you preferred to handle this so feel free to adjust as you please.