### PR TITLE
Change name for monitor/monitor_get and add a monitor_post

### DIFF
--- a/fortiosapi/fortiosapi.py
+++ b/fortiosapi/fortiosapi.py
@@ -31,11 +31,11 @@ import json
 import logging
 import subprocess
 import time
+import urllib
 from collections import OrderedDict
 
 import paramiko
 import requests
-import urllib
 
 from .exceptions import (InvalidLicense, NotLogged)
 
@@ -379,7 +379,7 @@ class FortiOSAPI(object):
         LOG.debug("POST raw results: %s", res)
         return self.formatresponse(res, vdom=vdom)
 
-    def exec(self, path, name, data, vdom=None, parameters=None):
+    def execute(self, path, name, data, vdom=None, parameters=None):
         LOG.debug("in EXEC function")
 
         url = self.mon_url(path, name, vdom)

--- a/fortiosapi/fortiosapi.py
+++ b/fortiosapi/fortiosapi.py
@@ -296,13 +296,6 @@ class FortiOSAPI(object):
         url = self.url_prefix + url_postfix
         return url
 
-    def monitor(self, path, name, vdom=None, mkey=None, parameters=None):
-        url = self.mon_url(path, name, vdom, mkey)
-        LOG.debug("in monitor url is %s", url)
-        res = self._session.get(url, params=parameters, timeout=self.timeout)
-        LOG.debug("in MONITOR function")
-        return self.formatresponse(res, vdom=vdom)
-
     def download(self, path, name, vdom=None, mkey=None, parameters=None):
         url = self.mon_url(path, name, vdom=vdom, mkey=mkey)
         res = self._session.get(url, params=parameters, timeout=self.timeout)
@@ -324,6 +317,17 @@ class FortiOSAPI(object):
         res = self._session.get(url, params=parameters, timeout=self.timeout)
         LOG.debug("in GET function")
         return self.formatresponse(res, vdom=vdom)
+
+    def monitor_get(self, path, name, vdom=None, mkey=None, parameters=None):
+        url = self.mon_url(path, name, vdom, mkey)
+        LOG.debug("in monitor url is %s", url)
+        res = self._session.get(url, params=parameters, timeout=self.timeout)
+        LOG.debug("in MONITOR function")
+        return self.formatresponse(res, vdom=vdom)
+
+    def monitor(self, path, name, vdom=None, mkey=None, parameters=None):  # Deprecated, use monitor_get
+        # Deprecated, use monitor_get
+        return self.monitor_get(path, name, vdom, mkey, parameters)
 
     def schema(self, path, name, vdom=None):
         # vdom or global is managed in cmdb_url
@@ -373,6 +377,16 @@ class FortiOSAPI(object):
         # post with mkey will return a 404 as the next level is not there yet
         # we pushed mkey in data if needed.
         url = self.cmdb_url(path, name, vdom, mkey=None)
+        LOG.debug("POST sent data : %s", json.dumps(data))
+        res = self._session.post(
+            url, params=parameters, data=json.dumps(data), timeout=self.timeout)
+        LOG.debug("POST raw results: %s", res)
+        return self.formatresponse(res, vdom=vdom)
+
+    def monitor_post(self, path, name, data, vdom=None, parameters=None):
+        LOG.debug("in POST function")
+
+        url = self.mon_url(path, name, vdom)
         LOG.debug("POST sent data : %s", json.dumps(data))
         res = self._session.post(
             url, params=parameters, data=json.dumps(data), timeout=self.timeout)

--- a/fortiosapi/fortiosapi.py
+++ b/fortiosapi/fortiosapi.py
@@ -379,10 +379,14 @@ class FortiOSAPI(object):
         LOG.debug("POST raw results: %s", res)
         return self.formatresponse(res, vdom=vdom)
 
-    def execute(self, path, name, data, vdom=None, parameters=None):
+    def execute(self, path, name, data, vdom=None,
+                mkey=None, parameters=None):
+        # execute is an action done on a running fortigate
+        # it is actually doing a post to the monitor part of the API
+        # we choose this name for clarity
         LOG.debug("in EXEC function")
 
-        url = self.mon_url(path, name, vdom)
+        url = self.mon_url(path, name, vdom, mkey=mkey)
         LOG.debug("EXEC sent data : %s", json.dumps(data))
         res = self._session.post(
             url, params=parameters, data=json.dumps(data), timeout=self.timeout)
@@ -487,10 +491,8 @@ class FortiOSAPI(object):
             return resp
         else:
             # if license not valid we try to update and check again
-            url = self.mon_url('system', 'fortiguard', mkey='update')
-            postres = self._session.post(url, timeout=self.timeout)
-            LOG.debug("Return POST fortiguard %s:", postres)
-            postresp = json.loads(postres.content.decode('utf-8'))
+            postresp = self.execute('system', 'fortiguard/update', None, vdom="root")
+            LOG.debug("Return EXECUTE fortiguard %s:", postresp)
             if postresp['status'] == 'success':
                 time.sleep(17)
                 return self.monitor('license', 'status')

--- a/fortiosapi/fortiosapi.py
+++ b/fortiosapi/fortiosapi.py
@@ -318,16 +318,12 @@ class FortiOSAPI(object):
         LOG.debug("in GET function")
         return self.formatresponse(res, vdom=vdom)
 
-    def monitor_get(self, path, name, vdom=None, mkey=None, parameters=None):
+    def monitor(self, path, name, vdom=None, mkey=None, parameters=None):
         url = self.mon_url(path, name, vdom, mkey)
         LOG.debug("in monitor url is %s", url)
         res = self._session.get(url, params=parameters, timeout=self.timeout)
         LOG.debug("in MONITOR function")
         return self.formatresponse(res, vdom=vdom)
-
-    def monitor(self, path, name, vdom=None, mkey=None, parameters=None):  # Deprecated, use monitor_get
-        # Deprecated, use monitor_get
-        return self.monitor_get(path, name, vdom, mkey, parameters)
 
     def schema(self, path, name, vdom=None):
         # vdom or global is managed in cmdb_url
@@ -383,14 +379,14 @@ class FortiOSAPI(object):
         LOG.debug("POST raw results: %s", res)
         return self.formatresponse(res, vdom=vdom)
 
-    def monitor_post(self, path, name, data, vdom=None, parameters=None):
-        LOG.debug("in POST function")
+    def exec(self, path, name, data, vdom=None, parameters=None):
+        LOG.debug("in EXEC function")
 
         url = self.mon_url(path, name, vdom)
-        LOG.debug("POST sent data : %s", json.dumps(data))
+        LOG.debug("EXEC sent data : %s", json.dumps(data))
         res = self._session.post(
             url, params=parameters, data=json.dumps(data), timeout=self.timeout)
-        LOG.debug("POST raw results: %s", res)
+        LOG.debug("EXEC raw results: %s", res)
         return self.formatresponse(res, vdom=vdom)
 
     def put(self, path, name, vdom=None,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
-paramiko
-requests
 pexpect
-oyaml
 nose
 packaging

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
-import setuptools
+from setuptools import setup, find_packages
 
 with open('README.md') as fh:
     long_description = fh.read()
 
-setuptools.setup(
+setup(
     name='fortiosapi',
-    version='0.10.7',
+    version='0.10.8',
     description="Python modules to use Fortigate APIs",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -20,7 +20,8 @@ setuptools.setup(
         'Topic :: Security',
     ],
     keywords='Fortinet fortigate fortios rest api',
-    packages=setuptools.find_packages(),
+    packages=find_packages(),
+    install_requires=['requests', 'paramiko', 'oyaml'],
     author='Nicolas Thomas',
     author_email='nthomas@fortinet.com',
     url='https://github.com/fortinet-solutions-cse/fortiosapi',

--- a/tests/test_fortiosapi_virsh.py
+++ b/tests/test_fortiosapi_virsh.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 import logging
 import os
-import pexpect
-import unittest
 import re
+import unittest
 
 import oyaml as yaml
+import pexpect
 from packaging.version import Version
 
 ###################################################################
@@ -235,6 +235,10 @@ class TestFortinetRestAPI(unittest.TestCase):
         }
         self.assertEqual(fgt.put('system', 'central-management', vdom="root", data=data)['status'], 'success')
 
+    def test_execute_update(self):
+        # Excuting the udate now command to ensure it does post to monitor interface (not compatible prior to 5.6)
+        self.assertEqual(fgt.execute('system', 'fortiguard/update', None, vdom="root")['status'], 'success')
+
     def test_webfilteripsv_set(self):
         # This call does not have mkey
         data = {
@@ -284,7 +288,7 @@ class TestFortinetRestAPI(unittest.TestCase):
                   'logtraffic': "all"
                     '''
         #        yamltree=OrderedDict()
-        yamltree = yaml.load(yamldata)
+        yamltree = yaml.load(yamldata, Loader=yaml.SafeLoader)
         self.assertTrue(fgt.setoverlayconfig(yamltree, vdom=conf['sut']['vdom']), True)
 
     def test_movecommand(self):

--- a/tests/test_fortiosapi_virsh.py
+++ b/tests/test_fortiosapi_virsh.py
@@ -238,6 +238,7 @@ class TestFortinetRestAPI(unittest.TestCase):
     def test_execute_update(self):
         # Excuting the udate now command to ensure it does post to monitor interface (not compatible prior to 5.6)
         self.assertEqual(fgt.execute('system', 'fortiguard/update', None, vdom="root")['status'], 'success')
+        self.assertEqual(fgt.execute('system', 'fortiguard', None, mkey="update", vdom="global")['status'], 'success')
 
     def test_webfilteripsv_set(self):
         # This call does not have mkey


### PR DESCRIPTION
Adding a monitor_post and change name of previous monitor call to monitor_get. Intention is to support monitor API in Ansible.