### PR TITLE
Updated documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Order of commands should be preserved.
 ## Login methods
 User/password
 
-Token (api key) documented in the Fortigate API Spec that you can find if having an account on http://fndn.fortinet.com/
+Token (api key) documented in the Fortigate API Spec that you can find if having an account on http://fndn.fortinet.net/
 
 ## Multi vdom
 In multi vdom environment use vdom=global in the API call.


### PR DESCRIPTION
Fortinet updated their URL to be .net instead of .com and the documentation URL resulted in an NXDOMAIN