### PR TITLE
Add 'port' keyword argument to login() and tokenlogin()

### DIFF
--- a/fortiosapi/fortiosapi.py
+++ b/fortiosapi/fortiosapi.py
@@ -467,12 +467,12 @@ class FortiOSAPI:
         # commands is a multiline string using the ''' string ''' format
         try:
             stdin, stdout, stderr = client.exec_command(cmds)
+            retcode = stdout.channel.recv_exit_status()
         except Exception:
             LOG.debug("exec_command failed")
-            raise subprocess.CalledProcessError(cmd=cmds)
+            raise subprocess.CalledProcessError(returncode=retcode, cmd=cmds)
         LOG.debug("ssh command in:  %s out: %s err: %s ",
                   stdin, stdout, stderr)
-        retcode = stdout.channel.recv_exit_status()
         LOG.debug("Paramiko return code : %s ", retcode)
         client.close()  # @TODO re-use connections
         if retcode > 0:


### PR DESCRIPTION
Found that if a FortiGate device (FortiOS v5.6.5, tested) is configured with
```
config system global
    set admin-port <something other than 80>
```
or 
```
    set admin-sport <something other than 443>
```
the `FortiOSAPI.login` method's request to `/logincheck` would not reach the device's REST API server.
I added a `port` attribute to the FortiOSAPI class, and optional keyword argument to both the `login` and `tokenlogin` methods to account for this configuration.

Also, small change to avoid 'undefined name' linting error in the first `CalledProcessError` in the `ssh` staticmethod.